### PR TITLE
Fix cookie

### DIFF
--- a/controllers/apiUserController.js
+++ b/controllers/apiUserController.js
@@ -9,6 +9,13 @@ const {
 } = require("../services/userService");
 
 const cookieFlags = (req) => {
+  if (req.get("Origin") === req.get("Host")) {
+    return {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+    };
+  }
   return {
     ...(process.env.NODE_ENV === "production" && { domain: req.hostname }), // add domain into cookie for production only
     httpOnly: true,

--- a/controllers/apiUserController.js
+++ b/controllers/apiUserController.js
@@ -9,7 +9,8 @@ const {
 } = require("../services/userService");
 
 const cookieFlags = (req) => {
-  if (req.get("Origin") === req.get("Host")) {
+  const thisHost = req.protocol + "://" + req.get("Host");
+  if (req.get("Origin") === thisHost) {
     return {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -11,7 +11,8 @@ const jwt = require("jsonwebtoken");
 
 const prisma = require("../db/prisma");
 const cookieFlags = (req) => {
-  if (req.get("Origin") === req.get("Host")) {
+  const thisHost = req.protocol + "://" + req.get("Host");
+  if (req.get("Origin") === thisHost) {
     return {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -11,6 +11,13 @@ const jwt = require("jsonwebtoken");
 
 const prisma = require("../db/prisma");
 const cookieFlags = (req) => {
+  if (req.get("Origin") === req.get("Host")) {
+    return {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+    };
+  }
   return {
     ...(process.env.NODE_ENV === "production" && { domain: req.hostname }), // add domain into cookie for production only
     httpOnly: true,


### PR DESCRIPTION
The cookie problem is that the code required support for 3rd party cookies.  This is a bad practice, as support for them can be turned off, and 3rd party cookies are being abandoned by the browsers.  So we need to provide another way in.

For development, we will use the vite proxy, and remap the origin, so that it is not a CORS request, and so that a host only cookie is set.

For deployment, the React front end must be deployed to Vercel.  Vercel provides a means to remap requests similar to what the Vite proxy does.

We still support CORS access, but that won't work if 3rd party cookies are disabled by the browser.