### PR TITLE
Fix cookie

### DIFF
--- a/controllers/apiUserController.js
+++ b/controllers/apiUserController.js
@@ -14,7 +14,7 @@ const cookieFlags = (req) => {
   if (
     rewriteHeader === "vercel" ||
     rewriteHeader === "vite" ||
-    req.getreq.get("Origin") === thisHost
+    req.get("Origin") === thisHost
   ) {
     return {
       httpOnly: true,

--- a/controllers/apiUserController.js
+++ b/controllers/apiUserController.js
@@ -10,7 +10,7 @@ const {
 
 const cookieFlags = (req) => {
   const thisHost = req.protocol + "://" + req.get("Host");
-  const rewriteHeader = req.get("XX-Same-Origin-Proxy");
+  const rewriteHeader = req.get("X-Same-Origin-Proxy");
   if (
     rewriteHeader === "vercel" ||
     rewriteHeader === "vite" ||

--- a/controllers/apiUserController.js
+++ b/controllers/apiUserController.js
@@ -10,7 +10,12 @@ const {
 
 const cookieFlags = (req) => {
   const thisHost = req.protocol + "://" + req.get("Host");
-  if (req.get("Origin") === thisHost) {
+  const rewriteHeader = req.get("XX-Same-Origin-Proxy");
+  if (
+    rewriteHeader === "vercel" ||
+    rewriteHeader === "vite" ||
+    req.getreq.get("Origin") === thisHost
+  ) {
     return {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -12,7 +12,12 @@ const jwt = require("jsonwebtoken");
 const prisma = require("../db/prisma");
 const cookieFlags = (req) => {
   const thisHost = req.protocol + "://" + req.get("Host");
-  if (req.get("Origin") === thisHost) {
+  const rewriteHeader = req.get("XX-Same-Origin-Proxy");
+  if (
+    rewriteHeader === "vercel" ||
+    rewriteHeader === "vite" ||
+    req.getreq.get("Origin") === thisHost
+  ) {
     return {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -16,7 +16,7 @@ const cookieFlags = (req) => {
   if (
     rewriteHeader === "vercel" ||
     rewriteHeader === "vite" ||
-    req.getreq.get("Origin") === thisHost
+    req.get("Origin") === thisHost
   ) {
     return {
       httpOnly: true,

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -12,7 +12,7 @@ const jwt = require("jsonwebtoken");
 const prisma = require("../db/prisma");
 const cookieFlags = (req) => {
   const thisHost = req.protocol + "://" + req.get("Host");
-  const rewriteHeader = req.get("XX-Same-Origin-Proxy");
+  const rewriteHeader = req.get("X-Same-Origin-Proxy");
   if (
     rewriteHeader === "vercel" ||
     rewriteHeader === "vite" ||


### PR DESCRIPTION
Another little change to cookie handling.  It is a bad practice to rewrite the origin, and it doesn't work on vercel, so we set a special header.  This has been tested at https://task-store.onrender.com.