### PR TITLE
require CSRF token for read operations on protected routes

### DIFF
--- a/middleware/jwtMiddleware.js
+++ b/middleware/jwtMiddleware.js
@@ -17,17 +17,10 @@ module.exports = async (req, res, next) => {
         send401(res);
       } else {
         req.user = { id: decoded.id };
-        if (
-          ["POST", "PATCH", "PUT", "DELETE", "CONNECT"].includes(req.method)
-        ) {
-          // for these operations we have to check for cross site request forgery
-          if (req.get("X-CSRF-TOKEN") == decoded.csrfToken) {
-            next();
-          } else {
-            send401(res);
-          }
-        } else {
+        if (req.get("X-CSRF-TOKEN") == decoded.csrfToken) {
           next();
+        } else {
+          send401(res);
         }
       }
     });


### PR DESCRIPTION
This would not typically be necessary, except we are effectively bypassing CORS, by setting allowed origins to true.  Because we are doing the latter, we have to protect read routes as well as write routes, otherwise a CSRF attack could read data.