### PR TITLE
Fix: Resolve TypeError when appending to ALLOWED_ORIGINS in app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,8 +28,8 @@ app.use(express.json({ limit: "100kb" }));
 app.use(xss());
 app.use(helmet());
 const port = process.env.PORT || 3000;
-// const origins = [];
-const origins = "http://localhost:3001";
+// Initialize as an array, including your default origin
+const origins = ["http://localhost:3001"];
 if (process.env.ALLOWED_ORIGINS) {
   const originArray = process.env.ALLOWED_ORIGINS.split(",");
   originArray.forEach((orig) => {


### PR DESCRIPTION
### **What does this PR do?**
This PR fixes a bug in `app.js` where the server crashes with a `TypeError: origins.push is not a function` if `ALLOWED_ORIGINS` are provided in the environment variables.

### **Why is this change necessary?**
Previously, the `origins` variable was initialized as a string (`"http://localhost:3001"`). When the code reached the `forEach` loop to add additional origins from the `.env` file, it attempted to call `.push()` on the string, which is an invalid method for string types in JavaScript.

### **What was changed?**

* Updated line 32 in `app.js`.
* Wrapped the default origin string in array brackets (`["http://localhost:3001"]`), changing its type from String to Array so the subsequent `.push()` method executes successfully.

### **Testing:**

* Verified that the server starts successfully with and without `ALLOWED_ORIGINS` defined in the `.env` file.
* Verified that the `.push()` method successfully appends additional origins without throwing a `TypeError`.